### PR TITLE
add possibility to join additional channels depending on the channel …

### DIFF
--- a/bin/xdcc-browse
+++ b/bin/xdcc-browse
@@ -53,6 +53,12 @@ def main(args: argparse.Namespace, logger: logging.Logger):
             logger.info("Downloading pack {}".format(pack))
 
         try:
+
+            additional_channel_map = {}
+            if args.additional_channel_map:
+                splits = args.additional_channel_map.split(":")
+                additional_channel_map[splits[0]] = splits[1]
+
             download_packs(
                 packs,
                 timeout=args.timeout,
@@ -60,7 +66,8 @@ def main(args: argparse.Namespace, logger: logging.Logger):
                 throttle=args.throttle,
                 wait_time=args.wait_time,
                 username=args.username,
-                channel_join_delay=args.channel_join_delay
+                channel_join_delay=args.channel_join_delay,
+                additional_channel_to_join=additional_channel_map
             )
         except ValueError:
             print("Invalid throttle value {}".format(args.throttle))

--- a/bin/xdcc-dl
+++ b/bin/xdcc-dl
@@ -42,6 +42,11 @@ def main(args: argparse.Namespace, logger: logging.Logger):
         )
         prepare_packs(packs, args.out)
 
+        additional_channel_map = {}
+        if args.additional_channel_map:
+            splits = args.additional_channel_map.split(":")
+            additional_channel_map[splits[0]] = splits[1]
+
         download_packs(
             packs,
             timeout=args.timeout,

--- a/xdcc_dl/helper.py
+++ b/xdcc_dl/helper.py
@@ -62,6 +62,9 @@ def add_xdcc_argparse_arguments(parser: ArgumentParser):
     parser.add_argument("--fallback-channel",
                         help="Fallback channel in case a channel could not"
                              "be joined automatically using WHOIS commands")
+    parser.add_argument("--additional-channel-map",
+                        help="2 channels; if the bot uses the first channel"
+                             "then the second is joined too. Format: #bot-chan:#additional-chan")
     parser.add_argument("--wait-time", default=0, type=int,
                         help="Waits for the specified amount of time before "
                              "sending the xdcc send request")

--- a/xdcc_dl/xdcc/__init__.py
+++ b/xdcc_dl/xdcc/__init__.py
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with xdcc-dl.  If not, see <http://www.gnu.org/licenses/>.
 LICENSE"""
 
-from typing import List, Optional, Union
+from typing import List, Optional, Union, Dict
 from xdcc_dl.entities.XDCCPack import XDCCPack
 from xdcc_dl.xdcc.XDCCClient import XDCCClient
 
@@ -29,7 +29,8 @@ def download_packs(
         throttle: Union[int, str] = -1,
         wait_time: int = 0,
         username: Optional[str] = None,
-        channel_join_delay: Optional[int] = None
+        channel_join_delay: Optional[int] = None,
+        additional_channel_to_join: Optional[Dict[str, str]] = None
 ):
     """
     Downloads a list of XDCC Packs
@@ -46,6 +47,7 @@ def download_packs(
     :param channel_join_delay: Delays the joining of channels by a set amount
                                of seconds. If not specified, the bot will wait
                                a random amount of time
+    :param additional_channel_to_join: map of a channel name that indicates to join a second channel
     :return: None
     """
     for pack in packs:
@@ -56,6 +58,7 @@ def download_packs(
             throttle=throttle,
             wait_time=wait_time,
             username="" if username is None else username,
-            channel_join_delay=channel_join_delay
+            channel_join_delay=channel_join_delay,
+            additional_channel_to_join = additional_channel_to_join
         )
         client.download()


### PR DESCRIPTION
This adds an additional option to specify channel dependencies. 

Specifying `--additional-channel-map "#A:#B"` results in: If the bot is in channel #A then it joins channel #A and #B.
This is needed sometimes.

Everything is backwards compatible.